### PR TITLE
Disable Composer lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
         },
+        "lock": false,
         "sort-packages": true
     }
 }


### PR DESCRIPTION
## Summary
- Disable Composer lock file generation for this library by setting `config.lock` to `false`.
- Keeps dependency resolution flexible for consumers while preserving normal Composer metadata.